### PR TITLE
Deploy webapp-vuxf via AppModelA

### DIFF
--- a/kratix/requests/README.md
+++ b/kratix/requests/README.md
@@ -68,7 +68,7 @@ Esta plantilla permite a los desarrolladores crear requests de aplicaciones usan
 platform-templates/templates/
 ├── app-model-a-request.yaml          # Template principal
 └── skeletons/app-model-a-request/
-    └── webapp-yhf5-default-request.yaml  # Template del request
+    └── webapp-vuxf-default-request.yaml  # Template del request
 ```
 
 ## 🚀 **Uso:**

--- a/kratix/requests/webapp-vuxf-default-request.yaml
+++ b/kratix/requests/webapp-vuxf-default-request.yaml
@@ -1,0 +1,45 @@
+apiVersion: platform.nttdata.io/v1alpha1
+kind: AppModelA
+metadata:
+  name: webapp-vuxf
+  namespace: kratix-system
+  labels:
+    app: webapp-vuxf
+    created-by: backstage
+    request-id: "vuxf"
+  annotations:
+    backstage.io/created-at: ""
+    backstage.io/requested-by: "unknown"
+spec:
+  appName: webapp-vuxf
+  namespace: default-vuxf
+  image: nginx:latest
+  port: 80
+  replicas: 1
+  serviceType: ClusterIP
+  imagePullPolicy: Always
+  gateway:
+    enabled: false
+    hostname: ""
+    gatewayName: "nginx-gateway"
+    gatewayNamespace: "nginx-gateway-system"
+    path: "/"
+    tls: false
+  storage:
+    enabled: false
+    size: "1Gi"
+    storageClass: "gp3"
+    mountPath: "/data"
+  database:
+    enabled: false
+    type: "postgresql"
+    claimApiVersion: "database.example.org/v1alpha1"
+    claimKind: "PostgreSQLInstance"
+    claimName: ""
+    parameters:
+      engine: "postgres"
+      version: "15"
+      instanceSize: "db.t3.micro"
+      storageGB: 20
+      username: "appuser"
+      publiclyAccessible: false


### PR DESCRIPTION
## New AppModelA Application Request with Unique Naming

**Application:** webapp-vuxf
**Base Name:** webapp
**Unique Suffix:** vuxf
**Namespace:** default
**Image:** nginx:latest
**Replicas:** 1

This deployment uses an automatically generated unique suffix to prevent naming conflicts.
