### PR TITLE
Deploy webapp-2fyq via AppModelA

### DIFF
--- a/kratix/requests/README.md
+++ b/kratix/requests/README.md
@@ -68,7 +68,7 @@ Esta plantilla permite a los desarrolladores crear requests de aplicaciones usan
 platform-templates/templates/
 ├── app-model-a-request.yaml          # Template principal
 └── skeletons/app-model-a-request/
-    └── webapp-pjzg-default-request.yaml  # Template del request
+    └── webapp-2fyq-default-request.yaml  # Template del request
 ```
 
 ## 🚀 **Uso:**

--- a/kratix/requests/webapp-2fyq-default-request.yaml
+++ b/kratix/requests/webapp-2fyq-default-request.yaml
@@ -1,0 +1,45 @@
+apiVersion: platform.nttdata.io/v1alpha1
+kind: AppModelA
+metadata:
+  name: webapp-2fyq
+  namespace: kratix-worker-system
+  labels:
+    app: webapp-2fyq
+    created-by: backstage
+    request-id: "2fyq"
+  annotations:
+    backstage.io/created-at: ""
+    backstage.io/requested-by: "unknown"
+spec:
+  appName: webapp-2fyq
+  namespace: default-2fyq
+  image: nginx:latest
+  port: 80
+  replicas: 1
+  serviceType: ClusterIP
+  imagePullPolicy: Always
+  gateway:
+    enabled: true
+    hostname: "myapp.nttdataco.com"
+    gatewayName: "nginx-gateway"
+    gatewayNamespace: "nginx-gateway-system"
+    path: "/"
+    tls: false
+  storage:
+    enabled: true
+    size: "1Gi"
+    storageClass: "gp3"
+    mountPath: "/data"
+  database:
+    enabled: true
+    type: "postgresql"
+    claimApiVersion: "database.example.org/v1alpha1"
+    claimKind: "PostgreSQLInstance"
+    claimName: "webapp-2fyq-db"
+    parameters:
+      engine: "postgres"
+      version: "15"
+      instanceSize: "small"
+      storageGB: 10
+      username: "{{ values.appName }}user"
+      publiclyAccessible: false


### PR DESCRIPTION
## New AppModelA Application Request with Unique Naming

**Application:** webapp-2fyq
**Base Name:** webapp
**Unique Suffix:** 2fyq
**Namespace:** default
**Image:** nginx:latest
**Replicas:** 1

This deployment uses an automatically generated unique suffix to prevent naming conflicts.
