### PR TITLE
Deploy webapp-53g4 via AppModelA

### DIFF
--- a/kratix/requests/README.md
+++ b/kratix/requests/README.md
@@ -68,7 +68,7 @@ Esta plantilla permite a los desarrolladores crear requests de aplicaciones usan
 platform-templates/templates/
 ├── app-model-a-request.yaml          # Template principal
 └── skeletons/app-model-a-request/
-    └── webapp-9hu3-default-request.yaml  # Template del request
+    └── webapp-53g4-default-request.yaml  # Template del request
 ```
 
 ## 🚀 **Uso:**

--- a/kratix/requests/webapp-53g4-default-request.yaml
+++ b/kratix/requests/webapp-53g4-default-request.yaml
@@ -1,0 +1,43 @@
+apiVersion: platform.nttdata.io/v1alpha1
+kind: AppModelA
+metadata:
+  name: webapp-53g4
+  namespace: kratix-worker-system
+  labels:
+    app: webapp-53g4
+    created-by: backstage
+    request-id: "53g4"
+  annotations:
+    backstage.io/created-at: ""
+    backstage.io/requested-by: "unknown"
+spec:
+  appName: webapp-53g4
+  namespace: default-53g4
+  image: nginx:latest
+  port: 80
+  replicas: 1
+  serviceType: ClusterIP
+  imagePullPolicy: Always
+  gateway:
+    enabled: true
+    hostname: "myapp.nttdataco.com"
+    gatewayName: "nginx-gateway"
+    gatewayNamespace: "nginx-gateway-system"
+    path: "/"
+    tls: false
+  storage:
+    enabled: true
+    size: "1Gi"
+    storageClass: "gp3"
+    mountPath: "/data"
+  database:
+    enabled: true
+    type: "postgresql"
+    claimName: "webapp-53g4-db"
+    parameters:
+      engine: "postgres"
+      version: "15"
+      instanceSize: "small"
+      storageGB: 10
+      username: "{{ values.appName }}user"
+      publiclyAccessible: false


### PR DESCRIPTION
## New AppModelA Application Request with Unique Naming

**Application:** webapp-53g4
**Base Name:** webapp
**Unique Suffix:** 53g4
**Namespace:** default
**Image:** nginx:latest
**Replicas:** 1

This deployment uses an automatically generated unique suffix to prevent naming conflicts.
