### PR TITLE
Deploy webapp-l1h8 via AppModelA

### DIFF
--- a/kratix/requests/README.md
+++ b/kratix/requests/README.md
@@ -68,7 +68,7 @@ Esta plantilla permite a los desarrolladores crear requests de aplicaciones usan
 platform-templates/templates/
 ├── app-model-a-request.yaml          # Template principal
 └── skeletons/app-model-a-request/
-    └── webapp-53g4-default-request.yaml  # Template del request
+    └── webapp-l1h8-default-request.yaml  # Template del request
 ```
 
 ## 🚀 **Uso:**

--- a/kratix/requests/webapp-l1h8-default-request.yaml
+++ b/kratix/requests/webapp-l1h8-default-request.yaml
@@ -1,0 +1,43 @@
+apiVersion: platform.nttdata.io/v1alpha1
+kind: AppModelA
+metadata:
+  name: webapp-l1h8
+  namespace: kratix-worker-system
+  labels:
+    app: webapp-l1h8
+    created-by: backstage
+    request-id: "l1h8"
+  annotations:
+    backstage.io/created-at: ""
+    backstage.io/requested-by: "unknown"
+spec:
+  appName: webapp-l1h8
+  namespace: default-l1h8
+  image: nginx:latest
+  port: 79
+  replicas: 1
+  serviceType: ClusterIP
+  imagePullPolicy: Always
+  gateway:
+    enabled: true
+    hostname: "myapp.nttdataco.com"
+    gatewayName: "nginx-gateway"
+    gatewayNamespace: "nginx-gateway-system"
+    path: "/"
+    tls: false
+  storage:
+    enabled: true
+    size: "1Gi"
+    storageClass: "gp2"
+    mountPath: "/data"
+  database:
+    enabled: true
+    type: "postgresql"
+    claimName: "webapp-l1h8-db"
+    parameters:
+      engine: "postgres"
+      version: "15"
+      instanceSize: "small"
+      storageGB: 10
+      username: "{{ values.appName }}user"
+      publiclyAccessible: false


### PR DESCRIPTION
## New AppModelA Application Request with Unique Naming

**Application:** webapp-l1h8
**Base Name:** webapp
**Unique Suffix:** l1h8
**Namespace:** default
**Image:** nginx:latest
**Replicas:** 1

This deployment uses an automatically generated unique suffix to prevent naming conflicts.
